### PR TITLE
更新博客个人简介和站点配置，体现全栈工程师身份

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,10 @@ timezone: Asia/Shanghai
 
 title: Weng # the main title
 
-tagline: daily writing # it will display as the subtitle
+tagline: 全栈开发笔记 | Full-Stack Dev Notes # it will display as the subtitle
 
 description: >- # used by seo meta and the atom feed
-  A minimal, responsive and feature-rich Jekyll theme for daily writing.
+  全栈工程师的技术博客，记录 Java/Spring Boot、Vue、Python 开发经验与项目实战。
 
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -4,15 +4,20 @@ icon: fas fa-info-circle
 order: 4
 ---
 
-> 欢迎来到我的个人博客！我是weng，一个热爱学习和分享的boy。Here is my notes.
+> 欢迎来到我的个人博客！我是 weng，一名全栈工程师，专注于 Java/Spring Boot 后端开发与 Vue 前端开发，同时也会使用 Python 进行脚本开发和数据处理。
 {: .prompt-tip }
 
-### 为什么建这个博客？
+### 技术栈
 
-- 记录学习过程，方便自己回顾
-- 分享知识，帮助他人
-- 通过写作提升自己的表达能力
-- 结识志同道合的朋友
+**后端**：Java / Spring Boot / MyBatis / MySQL
+**前端**：Vue / JavaScript / HTML / CSS
+**其他**：Python / Git / Docker / Linux
+
+### 博客内容
+
+- **技术笔记**：日常开发中积累的技术知识和实践经验
+- **项目复盘**：完整项目的开发过程、技术选型与踩坑记录
+- **学习记录**：英语学习、读书笔记等个人成长内容
 
 ### 联系方式
 


### PR DESCRIPTION
## Summary

- 重写 About 页面：明确全栈工程师身份，列出 Java/Spring Boot、Vue、Python 技术栈
- 更新站点 tagline：daily writing → 全栈开发笔记 | Full-Stack Dev Notes
- 更新 SEO description：改为全栈工程师技术博客定位

## 修改文件

- _tabs/about.md — 个人简介页面
- _config.yml — 站点配置（tagline + description）

## Test plan

- 访问 https://weng235.github.io 确认 tagline 显示正确
- 访问 About 页面确认个人简介内容正确

🤖 Generated with Claude Code